### PR TITLE
feat: firestore events

### DIFF
--- a/src/repositories/firestore/admin.ts
+++ b/src/repositories/firestore/admin.ts
@@ -7,6 +7,7 @@ import type {
     ID,
     Operators,
     Repository,
+    RepositoryEventListener,
     Table
 } from '@core/repositories/interface'
 
@@ -83,6 +84,12 @@ export interface FirebaseConstraints<Row extends Entity>
     where?: [keyof (Row & { __name__: string }), Operators, any][]
 }
 
+export type FirebaseEvents = 'create' | 'update' | 'remove'
+export interface FirebaseListeners {
+    [event: string]: {
+        [table: string]: RepositoryEventListener<any>[]
+    }
+}
 export interface FirebaseRepository extends Repository {
     query: <Row extends Entity>(
         table: Table,
@@ -96,115 +103,175 @@ export interface FirebaseRepository extends Repository {
     ) => Promise<number>
 }
 
-const getRepository = (db: admin.firestore.Firestore): FirebaseRepository => ({
-    bulkCreate: async (table, rows) => {
-        const batch = db.batch()
+const getRepository = (db: admin.firestore.Firestore): FirebaseRepository => {
+    const listeners: FirebaseListeners = {}
 
-        const createdRows = []
-        for (const { id, ...row } of rows) {
-            const doc = id
-                ? db.collection(table).doc(id)
-                : db.collection(table).doc()
-            createdRows.push({
-                id: doc.id,
-                ...row
-            })
-            batch.set(doc, row)
-        }
-
-        await batch.commit()
-
-        return createdRows
-    },
-
-    bulkRemove: async (table, ids) => {
-        const batch = db.batch()
-
-        for (const id of ids) {
-            const doc = db.collection(table).doc(id)
-            batch.delete(doc)
-        }
-
-        await batch.commit()
-    },
-
-    bulkUpdate: async (table, rows) => {
-        const batch = db.batch()
-
-        for (const row of rows) {
-            const doc = db.collection(table).doc(row.id)
-            batch.set(doc, row)
-        }
-
-        await batch.commit()
-    },
-
-    create: async (table, data, createId?) => {
-        if (createId) {
-            await db.collection(table).doc(createId).set(data)
-            return createId
-        }
-
-        const { id } = await db.collection(table).add(data)
-        return id
-    },
-
-    find: async (table: Table, id: ID) => {
-        if (!id) {
+    const triggerEvent = async (
+        event: FirebaseEvents,
+        table: Table,
+        data: Entity
+    ) => {
+        const eventListeners = listeners[event]?.[table]
+        if (!eventListeners) {
             return
         }
 
-        const doc = await db.collection(table).doc(id).get()
-        if (!doc) {
-            return
+        for (const listener of eventListeners) {
+            await listener(data)
         }
-
-        return await mapDocs(doc)
-    },
-
-    query: async (table, constraints = {}, fields?) => {
-        const { limit, orderBy, where } = constraints
-        let query: admin.firestore.Query<Entity> = db.collection(table)
-
-        if (where) {
-            for (const [field, operation, value] of where) {
-                query = query.where(field as string, operation, value)
-            }
-        }
-        if (orderBy) {
-            for (const [field, direction = 'asc'] of Object.entries(orderBy)) {
-                query = query.orderBy(field, direction)
-            }
-        }
-        if (limit) {
-            query = query.limit(limit)
-        }
-
-        const { docs } = await query.get()
-        return (await mapDocs(docs, fields)) || []
-    },
-
-    queryCount: async (table, constraints = {}) => {
-        const { where } = constraints
-        let query: admin.firestore.Query<Entity> = db.collection(table)
-
-        if (where) {
-            for (const [field, operation, value] of where) {
-                query = query.where(field as string, operation, value)
-            }
-        }
-
-        const snapshot = await query.count().get()
-        return snapshot.data().count
-    },
-
-    remove: async (table, id) => {
-        await db.collection(table).doc(id).delete()
-    },
-
-    update: async (table, id, data) => {
-        await db.collection(table).doc(id).update(data)
     }
-})
+
+    return {
+        bulkCreate: async (table, rows) => {
+            const batch = db.batch()
+
+            const createdRows = []
+            for (const { id, ...row } of rows) {
+                const doc = id
+                    ? db.collection(table).doc(id)
+                    : db.collection(table).doc()
+                createdRows.push({
+                    id: doc.id,
+                    ...row
+                })
+                batch.set(doc, row)
+            }
+
+            await batch.commit()
+
+            await triggerEvent('create', table, createdRows)
+
+            return createdRows
+        },
+
+        bulkRemove: async (table, ids) => {
+            const batch = db.batch()
+
+            for (const id of ids) {
+                const doc = db.collection(table).doc(id)
+                batch.delete(doc)
+            }
+
+            await batch.commit()
+
+            await triggerEvent('remove', table, { id: ids })
+        },
+
+        bulkUpdate: async (table, rows) => {
+            const batch = db.batch()
+
+            for (const row of rows) {
+                const doc = db.collection(table).doc(row.id)
+                batch.set(doc, row)
+            }
+
+            await batch.commit()
+
+            await triggerEvent('update', table, rows)
+        },
+
+        create: async (table, data, createId?) => {
+            if (createId) {
+                await db.collection(table).doc(createId).set(data)
+                return createId
+            }
+
+            const { id } = await db.collection(table).add(data)
+
+            await triggerEvent('create', table, { id, ...data })
+
+            return id
+        },
+
+        find: async (table: Table, id: ID) => {
+            if (!id) {
+                return
+            }
+
+            const doc = await db.collection(table).doc(id).get()
+            if (!doc) {
+                return
+            }
+
+            return await mapDocs(doc)
+        },
+
+        off: <Row extends Entity>(
+            event: string,
+            table: Table,
+            callback?: RepositoryEventListener<Row>
+        ) => {
+            if (!listeners[event]?.[table]) {
+                return
+            }
+
+            if (callback) {
+                listeners[event][table] = listeners[event][table].filter(
+                    (cb) => cb !== callback
+                )
+            } else {
+                listeners[event][table] = []
+            }
+        },
+
+        on: <Row extends Entity>(
+            event: string,
+            table: Table,
+            callback: RepositoryEventListener<Row>
+        ) => {
+            listeners[event] ??= {}
+            listeners[event]![table] ??= []
+            listeners[event]![table]!.push(callback)
+        },
+
+        query: async (table, constraints = {}, fields?) => {
+            const { limit, orderBy, where } = constraints
+            let query: admin.firestore.Query<Entity> = db.collection(table)
+
+            if (where) {
+                for (const [field, operation, value] of where) {
+                    query = query.where(field as string, operation, value)
+                }
+            }
+            if (orderBy) {
+                for (const [field, direction = 'asc'] of Object.entries(
+                    orderBy
+                )) {
+                    query = query.orderBy(field, direction)
+                }
+            }
+            if (limit) {
+                query = query.limit(limit)
+            }
+
+            const { docs } = await query.get()
+            return (await mapDocs(docs, fields)) || []
+        },
+
+        queryCount: async (table, constraints = {}) => {
+            const { where } = constraints
+            let query: admin.firestore.Query<Entity> = db.collection(table)
+
+            if (where) {
+                for (const [field, operation, value] of where) {
+                    query = query.where(field as string, operation, value)
+                }
+            }
+
+            const snapshot = await query.count().get()
+            return snapshot.data().count
+        },
+
+        remove: async (table, id) => {
+            await db.collection(table).doc(id).delete()
+            await triggerEvent('remove', table, { id })
+        },
+
+        update: async (table, id, data) => {
+            await db.collection(table).doc(id).update(data)
+            await triggerEvent('update', table, { id, ...data })
+        }
+    }
+}
 
 export default getRepository

--- a/src/repositories/firestore/admin.ts
+++ b/src/repositories/firestore/admin.ts
@@ -198,10 +198,13 @@ const getRepository = (db: admin.firestore.Firestore): FirebaseRepository => ({
         return snapshot.data().count
     },
 
-    remove: async (table, id) => void db.collection(table).doc(id).delete(),
+    remove: async (table, id) => {
+        await db.collection(table).doc(id).delete()
+    },
 
-    update: async (table, id, data) =>
-        void db.collection(table).doc(id).update(data)
+    update: async (table, id, data) => {
+        await db.collection(table).doc(id).update(data)
+    }
 })
 
 export default getRepository

--- a/src/repositories/firestore/mock.test.ts
+++ b/src/repositories/firestore/mock.test.ts
@@ -57,328 +57,666 @@ describe('firestore', () => {
         expect(getRawMockData()).toEqual({})
     })
 
-    it('should return the id when creating an entry', async () => {
-        const db = getMockDB()
-        const repo = getRepository(db)
-        const id = await repo.create('members', { name: 'John' })
-        expect(id).toBe('0')
-    })
-
-    it('should use the createId when provided', async () => {
-        const db = getMockDB()
-        const repo = getRepository(db)
-        const id = await repo.create('members', { name: 'John' }, '2')
-        expect(id).toBe('2')
-        expect(Object.keys(getRawMockData().members)[0]).toBe('2')
-    })
-
-    it('should reflect the entry in the database after creation', async () => {
-        const db = getMockDB()
-        const repo = getRepository(db)
-        const id = await repo.create('members', { name: 'John' })
-
-        expect(id).toBe('0')
-        expect(Object.keys(getRawMockData().members)).toHaveLength(1)
-        expect(getRawMockData().members['0']).toEqual({ name: 'John' })
-    })
-
-    it('should bulk add entries into the database', async () => {
-        const db = getMockDB()
-        const repo = getRepository(db)
-        const members = await repo.bulkCreate('members', [
-            { name: 'John' },
-            { name: 'Jane' }
-        ])
-
-        expect(members).toHaveLength(2)
-        expect(Object.keys(getRawMockData().members)).toHaveLength(2)
-        expect(getRawMockData().members['0']).toEqual({ name: 'John' })
-        expect(getRawMockData().members['1']).toEqual({ name: 'Jane' })
-    })
-
-    it('should add the id as a property for entries returned with find', async () => {
-        const db = getMockDB()
-        const repo = getRepository(db)
-
-        seedMockRepository('members', [{ name: 'John' }, { name: 'Jane' }])
-
-        const member = await repo.find('members', '0')
-        expect(member).toEqual({ id: '0', name: 'John' })
-    })
-
-    it('should add the id as a property for entries returned with query', async () => {
-        const db = getMockDB()
-        const repo = getRepository(db)
-
-        seedMockRepository('members', [{ name: 'John' }])
-
-        const members = await repo.query('members')
-        expect(members).toEqual([{ id: '0', name: 'John' }])
-    })
-
-    it('should find the correct entry by id', async () => {
-        const db = getMockDB()
-        const repo = getRepository(db)
-
-        seedMockRepository('members', [{ name: 'John' }, { name: 'Jane' }])
-
-        const member1 = await repo.find('members', '0')
-        expect(member1).toEqual({ id: '0', name: 'John' })
-
-        const member2 = await repo.find('members', '1')
-        expect(member2).toEqual({ id: '1', name: 'Jane' })
-    })
-
-    it('should remove the correct entry by id', async () => {
-        const db = getMockDB()
-        const repo = getRepository(db)
-
-        seedMockRepository('members', [
-            { name: 'John' },
-            { name: 'Jane' },
-            { name: 'Jack' }
-        ])
-
-        await repo.remove('members', '1')
-
-        expect(Object.keys(getRawMockData().members)).toHaveLength(2)
-        expect(getRawMockData().members['0']).toEqual({ name: 'John' })
-        expect(getRawMockData().members['1']).toBeUndefined()
-        expect(getRawMockData().members['2']).toEqual({ name: 'Jack' })
-    })
-
-    it('should bulk remove the correct entries', async () => {
-        const db = getMockDB()
-        const repo = getRepository(db)
-
-        seedMockRepository('members', [
-            { name: 'John' },
-            { name: 'Jane' },
-            { name: 'Jack' }
-        ])
-
-        await repo.bulkRemove('members', ['1', '2'])
-
-        expect(Object.keys(getRawMockData().members)).toHaveLength(1)
-        expect(getRawMockData().members['0']).toEqual({ name: 'John' })
-        expect(getRawMockData().members['1']).toBeUndefined()
-        expect(getRawMockData().members['2']).toBeUndefined()
-    })
-
-    it('should update the correct entry by id', async () => {
-        const db = getMockDB()
-        const repo = getRepository(db)
-
-        seedMockRepository('members', [
-            { name: 'John' },
-            { name: 'Jane' },
-            { name: 'Jack' }
-        ])
-
-        await repo.update('members', '1', { name: 'Jill' })
-
-        expect(Object.keys(getRawMockData().members)).toHaveLength(3)
-        expect(getRawMockData().members['0']).toEqual({ name: 'John' })
-        expect(getRawMockData().members['1']).toEqual({ name: 'Jill' })
-        expect(getRawMockData().members['2']).toEqual({ name: 'Jack' })
-
-        await repo.update('members', '1', { age: 20, name: 'Jill' })
-
-        expect(Object.keys(getRawMockData().members)).toHaveLength(3)
-        expect(getRawMockData().members['0']).toEqual({ name: 'John' })
-        expect(getRawMockData().members['1']).toEqual({ age: 20, name: 'Jill' })
-        expect(getRawMockData().members['2']).toEqual({ name: 'Jack' })
-    })
-
-    it('should remove entries with the deleteTransform value on update', async () => {
-        const db = getMockDB()
-        const repo = getRepository(db)
-
-        seedMockRepository('members', [
-            { name: 'John' },
-            { age: 20, name: 'Jane' },
-            { name: 'Jack' }
-        ])
-
-        await repo.update('members', '1', { age: FieldValue.delete() })
-
-        expect(Object.keys(getRawMockData().members)).toHaveLength(3)
-        expect(getRawMockData().members['0']).toEqual({ name: 'John' })
-        expect(getRawMockData().members['1']).toEqual({ name: 'Jane' })
-        expect(getRawMockData().members['2']).toEqual({ name: 'Jack' })
-    })
-
-    it('should filter queries by constraints', async () => {
-        const db = getMockDB()
-        const repo = getRepository(db)
-
-        seedMockRepository('members', [
-            { name: 'John' },
-            { age: 20, name: 'Jane' },
-            { name: 'Jack' },
-            { age: 27, name: 'Jane' }
-        ])
-
-        const members = await repo.query<Member>('members', {
-            where: [['name', '==', 'Jane']]
+    describe('crud operations', () => {
+        it('should return the id when creating an entry', async () => {
+            const db = getMockDB()
+            const repo = getRepository(db)
+            const id = await repo.create('members', { name: 'John' })
+            expect(id).toBe('0')
         })
 
-        expect(members).toEqual([
-            { age: 20, id: '1', name: 'Jane' },
-            { age: 27, id: '3', name: 'Jane' }
-        ])
-    })
-
-    it('should reduce query responses to the requested fields', async () => {
-        const db = getMockDB()
-        const repo = getRepository(db)
-
-        seedMockRepository('members', [
-            { name: 'John' },
-            { age: 20, name: 'Jane' },
-            { name: 'Jack' },
-            { age: 27, name: 'Jane' }
-        ])
-
-        const memberIds = await repo.query<Member>('members', undefined, ['id'])
-
-        expect(memberIds).toEqual([
-            { id: '0' },
-            { id: '1' },
-            { id: '2' },
-            { id: '3' }
-        ])
-
-        const memberNames = await repo.query<Member>('members', undefined, [
-            'name'
-        ])
-
-        expect(memberNames).toEqual([
-            { name: 'John' },
-            { name: 'Jane' },
-            { name: 'Jack' },
-            { name: 'Jane' }
-        ])
-    })
-
-    it('should support __name__ as a constraint', async () => {
-        const db = getMockDB()
-        const repo = getRepository(db)
-
-        seedMockRepository('members', [
-            { name: 'John' },
-            { age: 20, name: 'Jane' },
-            { name: 'Jack' },
-            { age: 27, name: 'Jane' }
-        ])
-
-        const members = await repo.query<Member>('members', {
-            where: [['__name__', '==', '1']]
+        it('should use the createId when provided', async () => {
+            const db = getMockDB()
+            const repo = getRepository(db)
+            const id = await repo.create('members', { name: 'John' }, '2')
+            expect(id).toBe('2')
+            expect(Object.keys(getRawMockData().members)[0]).toBe('2')
         })
 
-        expect(members).toEqual([{ age: 20, id: '1', name: 'Jane' }])
-    })
+        it('should reflect the entry in the database after creation', async () => {
+            const db = getMockDB()
+            const repo = getRepository(db)
+            const id = await repo.create('members', { name: 'John' })
 
-    it('should support __name__ for ordering', async () => {
-        const db = getMockDB()
-        const repo = getRepository(db)
-
-        seedMockRepository('members', [
-            { name: 'John' },
-            { age: 20, name: 'Jane' },
-            { name: 'Jack' },
-            { age: 27, name: 'Jane' }
-        ])
-
-        const members = await repo.query<Member>('members', {
-            orderBy: { __name__: 'desc' }
+            expect(id).toBe('0')
+            expect(Object.keys(getRawMockData().members)).toHaveLength(1)
+            expect(getRawMockData().members['0']).toEqual({ name: 'John' })
         })
 
-        expect(members).toEqual([
-            { age: 27, id: '3', name: 'Jane' },
-            { id: '2', name: 'Jack' },
-            { age: 20, id: '1', name: 'Jane' },
-            { id: '0', name: 'John' }
-        ])
-    })
+        it('should bulk add entries into the database', async () => {
+            const db = getMockDB()
+            const repo = getRepository(db)
+            const members = await repo.bulkCreate('members', [
+                { name: 'John' },
+                { name: 'Jane' }
+            ])
 
-    it('should AND multiple query constraints together', async () => {
-        const db = getMockDB()
-        const repo = getRepository(db)
+            expect(members).toHaveLength(2)
+            expect(Object.keys(getRawMockData().members)).toHaveLength(2)
+            expect(getRawMockData().members['0']).toEqual({ name: 'John' })
+            expect(getRawMockData().members['1']).toEqual({ name: 'Jane' })
+        })
 
-        seedMockRepository('members', [
-            { name: 'John' },
-            { age: 20, name: 'Jane' },
-            { name: 'Jack' },
-            { age: 27, name: 'Jane' }
-        ])
+        it('should add the id as a property for entries returned with find', async () => {
+            const db = getMockDB()
+            const repo = getRepository(db)
 
-        const members = await repo.query<Member>('members', {
-            where: [
-                ['name', '==', 'Jane'],
-                ['age', '>=', 25]
+            seedMockRepository('members', [{ name: 'John' }, { name: 'Jane' }])
+
+            const member = await repo.find('members', '0')
+            expect(member).toEqual({ id: '0', name: 'John' })
+        })
+
+        it('should add the id as a property for entries returned with query', async () => {
+            const db = getMockDB()
+            const repo = getRepository(db)
+
+            seedMockRepository('members', [{ name: 'John' }])
+
+            const members = await repo.query('members')
+            expect(members).toEqual([{ id: '0', name: 'John' }])
+        })
+
+        it('should find the correct entry by id', async () => {
+            const db = getMockDB()
+            const repo = getRepository(db)
+
+            seedMockRepository('members', [{ name: 'John' }, { name: 'Jane' }])
+
+            const member1 = await repo.find('members', '0')
+            expect(member1).toEqual({ id: '0', name: 'John' })
+
+            const member2 = await repo.find('members', '1')
+            expect(member2).toEqual({ id: '1', name: 'Jane' })
+        })
+
+        it('should remove the correct entry by id', async () => {
+            const db = getMockDB()
+            const repo = getRepository(db)
+
+            seedMockRepository('members', [
+                { name: 'John' },
+                { name: 'Jane' },
+                { name: 'Jack' }
+            ])
+
+            await repo.remove('members', '1')
+
+            expect(Object.keys(getRawMockData().members)).toHaveLength(2)
+            expect(getRawMockData().members['0']).toEqual({ name: 'John' })
+            expect(getRawMockData().members['1']).toBeUndefined()
+            expect(getRawMockData().members['2']).toEqual({ name: 'Jack' })
+        })
+
+        it('should bulk remove the correct entries', async () => {
+            const db = getMockDB()
+            const repo = getRepository(db)
+
+            seedMockRepository('members', [
+                { name: 'John' },
+                { name: 'Jane' },
+                { name: 'Jack' }
+            ])
+
+            await repo.bulkRemove('members', ['1', '2'])
+
+            expect(Object.keys(getRawMockData().members)).toHaveLength(1)
+            expect(getRawMockData().members['0']).toEqual({ name: 'John' })
+            expect(getRawMockData().members['1']).toBeUndefined()
+            expect(getRawMockData().members['2']).toBeUndefined()
+        })
+
+        it('should update the correct entry by id', async () => {
+            const db = getMockDB()
+            const repo = getRepository(db)
+
+            seedMockRepository('members', [
+                { name: 'John' },
+                { name: 'Jane' },
+                { name: 'Jack' }
+            ])
+
+            await repo.update('members', '1', { name: 'Jill' })
+
+            expect(Object.keys(getRawMockData().members)).toHaveLength(3)
+            expect(getRawMockData().members['0']).toEqual({ name: 'John' })
+            expect(getRawMockData().members['1']).toEqual({ name: 'Jill' })
+            expect(getRawMockData().members['2']).toEqual({ name: 'Jack' })
+
+            await repo.update('members', '1', { age: 20, name: 'Jill' })
+
+            expect(Object.keys(getRawMockData().members)).toHaveLength(3)
+            expect(getRawMockData().members['0']).toEqual({ name: 'John' })
+            expect(getRawMockData().members['1']).toEqual({
+                age: 20,
+                name: 'Jill'
+            })
+            expect(getRawMockData().members['2']).toEqual({ name: 'Jack' })
+        })
+
+        it('should remove entries with the deleteTransform value on update', async () => {
+            const db = getMockDB()
+            const repo = getRepository(db)
+
+            seedMockRepository('members', [
+                { name: 'John' },
+                { age: 20, name: 'Jane' },
+                { name: 'Jack' }
+            ])
+
+            await repo.update('members', '1', { age: FieldValue.delete() })
+
+            expect(Object.keys(getRawMockData().members)).toHaveLength(3)
+            expect(getRawMockData().members['0']).toEqual({ name: 'John' })
+            expect(getRawMockData().members['1']).toEqual({ name: 'Jane' })
+            expect(getRawMockData().members['2']).toEqual({ name: 'Jack' })
+        })
+
+        it('should filter queries by constraints', async () => {
+            const db = getMockDB()
+            const repo = getRepository(db)
+
+            seedMockRepository('members', [
+                { name: 'John' },
+                { age: 20, name: 'Jane' },
+                { name: 'Jack' },
+                { age: 27, name: 'Jane' }
+            ])
+
+            const members = await repo.query<Member>('members', {
+                where: [['name', '==', 'Jane']]
+            })
+
+            expect(members).toEqual([
+                { age: 20, id: '1', name: 'Jane' },
+                { age: 27, id: '3', name: 'Jane' }
+            ])
+        })
+
+        it('should reduce query responses to the requested fields', async () => {
+            const db = getMockDB()
+            const repo = getRepository(db)
+
+            seedMockRepository('members', [
+                { name: 'John' },
+                { age: 20, name: 'Jane' },
+                { name: 'Jack' },
+                { age: 27, name: 'Jane' }
+            ])
+
+            const memberIds = await repo.query<Member>('members', undefined, [
+                'id'
+            ])
+
+            expect(memberIds).toEqual([
+                { id: '0' },
+                { id: '1' },
+                { id: '2' },
+                { id: '3' }
+            ])
+
+            const memberNames = await repo.query<Member>('members', undefined, [
+                'name'
+            ])
+
+            expect(memberNames).toEqual([
+                { name: 'John' },
+                { name: 'Jane' },
+                { name: 'Jack' },
+                { name: 'Jane' }
+            ])
+        })
+
+        it('should support __name__ as a constraint', async () => {
+            const db = getMockDB()
+            const repo = getRepository(db)
+
+            seedMockRepository('members', [
+                { name: 'John' },
+                { age: 20, name: 'Jane' },
+                { name: 'Jack' },
+                { age: 27, name: 'Jane' }
+            ])
+
+            const members = await repo.query<Member>('members', {
+                where: [['__name__', '==', '1']]
+            })
+
+            expect(members).toEqual([{ age: 20, id: '1', name: 'Jane' }])
+        })
+
+        it('should support __name__ for ordering', async () => {
+            const db = getMockDB()
+            const repo = getRepository(db)
+
+            seedMockRepository('members', [
+                { name: 'John' },
+                { age: 20, name: 'Jane' },
+                { name: 'Jack' },
+                { age: 27, name: 'Jane' }
+            ])
+
+            const members = await repo.query<Member>('members', {
+                orderBy: { __name__: 'desc' }
+            })
+
+            expect(members).toEqual([
+                { age: 27, id: '3', name: 'Jane' },
+                { id: '2', name: 'Jack' },
+                { age: 20, id: '1', name: 'Jane' },
+                { id: '0', name: 'John' }
+            ])
+        })
+
+        it('should AND multiple query constraints together', async () => {
+            const db = getMockDB()
+            const repo = getRepository(db)
+
+            seedMockRepository('members', [
+                { name: 'John' },
+                { age: 20, name: 'Jane' },
+                { name: 'Jack' },
+                { age: 27, name: 'Jane' }
+            ])
+
+            const members = await repo.query<Member>('members', {
+                where: [
+                    ['name', '==', 'Jane'],
+                    ['age', '>=', 25]
+                ]
+            })
+
+            expect(members).toEqual([{ age: 27, id: '3', name: 'Jane' }])
+        })
+
+        it('should be possible to limit the amount of rows returned by query', async () => {
+            const db = getMockDB()
+            const repo = getRepository(db)
+
+            seedMockRepository('members', [
+                { name: 'John' },
+                { age: 20, name: 'Jane' },
+                { name: 'Jack' },
+                { age: 27, name: 'Jane' }
+            ])
+
+            const members = await repo.query<Member>('members', {
+                limit: 2
+            })
+
+            expect(members).toEqual([
+                { id: '0', name: 'John' },
+                { age: 20, id: '1', name: 'Jane' }
+            ])
+        })
+
+        it('should return only requested query fields', async () => {
+            const db = getMockDB()
+            const repo = getRepository(db)
+
+            seedMockRepository('members', [
+                { name: 'John' },
+                { age: 20, name: 'Jane' },
+                { name: 'Jack' },
+                { age: 27, name: 'Jane' }
+            ])
+
+            const members = await repo.query<Member>('members', undefined, [
+                'name'
+            ])
+
+            expect(members).toEqual([
+                { name: 'John' },
+                { name: 'Jane' },
+                { name: 'Jack' },
+                { name: 'Jane' }
+            ])
+        })
+
+        it('should return correct count for queryCount', async () => {
+            const db = getMockDB()
+            const repo = getRepository(db)
+
+            const mockMembers = [
+                { name: 'John' },
+                { age: 20, name: 'Jane' },
+                { name: 'Jack' },
+                { age: 27, name: 'Jane' }
             ]
+            seedMockRepository('members', mockMembers)
+
+            const members = await repo.queryCount<Member>('members')
+
+            expect(members).toEqual(mockMembers.length)
+        })
+    })
+
+    describe('events', () => {
+        it('should trigger the "create" event when creating an entry', async () => {
+            const db = getMockDB()
+            const repo = getRepository(db)
+            const memberListener = {
+                callback: async () => {}
+            }
+
+            const memberSpy = vi.spyOn(memberListener, 'callback')
+
+            repo.on('create', 'members', memberListener.callback)
+
+            await repo.create('members', { name: 'John' })
+
+            expect(memberSpy).toHaveBeenCalledTimes(1)
+            expect(memberSpy).toHaveBeenCalledWith({
+                id: '0',
+                name: 'John'
+            })
+
+            await repo.create('members', { age: 20, name: 'Jane' })
+
+            expect(memberSpy).toHaveBeenCalledTimes(2)
+            expect(memberSpy).toHaveBeenCalledWith({
+                age: 20,
+                id: '1',
+                name: 'Jane'
+            })
         })
 
-        expect(members).toEqual([{ age: 27, id: '3', name: 'Jane' }])
-    })
+        it('should trigger the "update" event when updating an entry', async () => {
+            const db = getMockDB()
+            const repo = getRepository(db)
 
-    it('should be possible to limit the amount of rows returned by query', async () => {
-        const db = getMockDB()
-        const repo = getRepository(db)
+            seedMockRepository('members', [
+                { name: 'John' },
+                { name: 'Jane' },
+                { name: 'Jack' }
+            ])
+            const memberListener = {
+                callback: async () => {}
+            }
 
-        seedMockRepository('members', [
-            { name: 'John' },
-            { age: 20, name: 'Jane' },
-            { name: 'Jack' },
-            { age: 27, name: 'Jane' }
-        ])
+            const memberSpy = vi.spyOn(memberListener, 'callback')
 
-        const members = await repo.query<Member>('members', {
-            limit: 2
+            repo.on('update', 'members', memberListener.callback)
+
+            await repo.update('members', '1', { name: 'Jill' })
+
+            expect(memberSpy).toHaveBeenCalledTimes(1)
+            expect(memberSpy).toHaveBeenCalledWith({
+                id: '1',
+                name: 'Jill'
+            })
+
+            await repo.update('members', '1', { age: 20, name: 'Jill' })
+
+            expect(memberSpy).toHaveBeenCalledTimes(2)
+            expect(memberSpy).toHaveBeenCalledWith({
+                age: 20,
+                id: '1',
+                name: 'Jill'
+            })
         })
 
-        expect(members).toEqual([
-            { id: '0', name: 'John' },
-            { age: 20, id: '1', name: 'Jane' }
-        ])
-    })
+        it('should trigger the "remove" event when removing an entry', async () => {
+            const db = getMockDB()
+            const repo = getRepository(db)
 
-    it('should return only requested query fields', async () => {
-        const db = getMockDB()
-        const repo = getRepository(db)
+            seedMockRepository('members', [
+                { name: 'John' },
+                { name: 'Jane' },
+                { name: 'Jack' }
+            ])
+            const memberListener = {
+                callback: async () => {}
+            }
 
-        seedMockRepository('members', [
-            { name: 'John' },
-            { age: 20, name: 'Jane' },
-            { name: 'Jack' },
-            { age: 27, name: 'Jane' }
-        ])
+            const memberSpy = vi.spyOn(memberListener, 'callback')
 
-        const members = await repo.query<Member>('members', undefined, ['name'])
+            repo.on('remove', 'members', memberListener.callback)
 
-        expect(members).toEqual([
-            { name: 'John' },
-            { name: 'Jane' },
-            { name: 'Jack' },
-            { name: 'Jane' }
-        ])
-    })
+            await repo.remove('members', '1')
 
-    it('should return correct count for queryCount', async () => {
-        const db = getMockDB()
-        const repo = getRepository(db)
+            expect(memberSpy).toHaveBeenCalledTimes(1)
+            expect(memberSpy).toHaveBeenCalledWith({ id: '1' })
 
-        const mockMembers = [
-            { name: 'John' },
-            { age: 20, name: 'Jane' },
-            { name: 'Jack' },
-            { age: 27, name: 'Jane' }
-        ]
-        seedMockRepository('members', mockMembers)
+            await repo.remove('members', '2')
 
-        const members = await repo.queryCount<Member>('members')
+            expect(memberSpy).toHaveBeenCalledTimes(2)
+            expect(memberSpy).toHaveBeenCalledWith({
+                id: '2'
+            })
+        })
 
-        expect(members).toEqual(mockMembers.length)
+        it('should not trigger other events', async () => {
+            const db = getMockDB()
+            const repo = getRepository(db)
+
+            const memberListener = {
+                createCallback: async () => {},
+                removeCallback: async () => {},
+                updateCallback: async () => {}
+            }
+
+            const createSpy = vi.spyOn(memberListener, 'createCallback')
+            const updateSpy = vi.spyOn(memberListener, 'updateCallback')
+            const removeSpy = vi.spyOn(memberListener, 'removeCallback')
+
+            repo.on('create', 'members', memberListener.createCallback)
+            repo.on('update', 'members', memberListener.updateCallback)
+            repo.on('remove', 'members', memberListener.removeCallback)
+
+            await repo.create('members', { name: 'John' })
+
+            expect(createSpy).toHaveBeenCalledTimes(1)
+            expect(updateSpy).not.toHaveBeenCalled()
+            expect(removeSpy).not.toHaveBeenCalled()
+
+            await repo.update('members', '0', { name: 'Jane' })
+
+            expect(createSpy).toHaveBeenCalledTimes(1)
+            expect(updateSpy).toHaveBeenCalledTimes(1)
+            expect(removeSpy).not.toHaveBeenCalled()
+
+            await repo.remove('members', '0')
+
+            expect(createSpy).toHaveBeenCalledTimes(1)
+            expect(updateSpy).toHaveBeenCalledTimes(1)
+            expect(removeSpy).toHaveBeenCalledTimes(1)
+        })
+
+        it('should not trigger events of other tables', async () => {
+            const db = getMockDB()
+            const repo = getRepository(db)
+
+            seedMockRepository('members', [{ name: 'John' }])
+            seedMockRepository('users', [{ name: 'John' }])
+
+            const memberListener = {
+                callback: async () => {}
+            }
+
+            const userListener = {
+                callback: async () => {}
+            }
+
+            const memberSpy = vi.spyOn(memberListener, 'callback')
+            const userSpy = vi.spyOn(userListener, 'callback')
+
+            repo.on('update', 'members', memberListener.callback)
+
+            await repo.update('members', '0', { name: 'Jane' })
+
+            expect(memberSpy).toHaveBeenCalledTimes(1)
+            expect(userSpy).not.toHaveBeenCalled()
+        })
+
+        it('should be possible to register multiple listeners', async () => {
+            const db = getMockDB()
+            const repo = getRepository(db)
+
+            seedMockRepository('members', [{ name: 'John' }])
+            const memberListener1 = {
+                callback: async () => {}
+            }
+            const memberListener2 = {
+                callback: async () => {}
+            }
+
+            const memberSpy1 = vi.spyOn(memberListener1, 'callback')
+            const memberSpy2 = vi.spyOn(memberListener2, 'callback')
+
+            repo.on('update', 'members', memberListener1.callback)
+            repo.on('update', 'members', memberListener2.callback)
+
+            await repo.update('members', '0', { name: 'Jane' })
+
+            expect(memberSpy1).toHaveBeenCalledTimes(1)
+            expect(memberSpy2).toHaveBeenCalledTimes(1)
+        })
+
+        it('should be possible to unregister a single listener', async () => {
+            const db = getMockDB()
+            const repo = getRepository(db)
+
+            seedMockRepository('members', [{ name: 'John' }])
+            const memberListener1 = {
+                callback: async () => {}
+            }
+            const memberListener2 = {
+                callback: async () => {}
+            }
+
+            const memberSpy1 = vi.spyOn(memberListener1, 'callback')
+            const memberSpy2 = vi.spyOn(memberListener2, 'callback')
+
+            repo.on('update', 'members', memberListener1.callback)
+            repo.on('update', 'members', memberListener2.callback)
+
+            await repo.update('members', '0', { name: 'Jane' })
+
+            expect(memberSpy1).toHaveBeenCalledTimes(1)
+            expect(memberSpy2).toHaveBeenCalledTimes(1)
+
+            repo.off('update', 'members', memberListener1.callback)
+
+            await repo.update('members', '0', { age: 20, name: 'Jill' })
+
+            expect(memberSpy1).toHaveBeenCalledTimes(1)
+            expect(memberSpy2).toHaveBeenCalledTimes(2)
+
+            repo.off('update', 'members', memberListener2.callback)
+
+            expect(memberSpy1).toHaveBeenCalledTimes(1)
+            expect(memberSpy2).toHaveBeenCalledTimes(2)
+        })
+
+        it('should be possible to unregister all listeners', async () => {
+            const db = getMockDB()
+            const repo = getRepository(db)
+
+            seedMockRepository('members', [{ name: 'John' }])
+
+            const memberListener1 = {
+                callback: async () => {}
+            }
+            const memberListener2 = {
+                callback: async () => {}
+            }
+
+            const memberSpy1 = vi.spyOn(memberListener1, 'callback')
+            const memberSpy2 = vi.spyOn(memberListener2, 'callback')
+
+            repo.on('update', 'members', memberListener1.callback)
+            repo.on('update', 'members', memberListener2.callback)
+
+            await repo.update('members', '0', { name: 'Jane' })
+
+            expect(memberSpy1).toHaveBeenCalledTimes(1)
+            expect(memberSpy2).toHaveBeenCalledTimes(1)
+
+            repo.off('update', 'members')
+
+            await repo.update('members', '0', { age: 20, name: 'Jill' })
+
+            expect(memberSpy1).toHaveBeenCalledTimes(1)
+            expect(memberSpy2).toHaveBeenCalledTimes(1)
+        })
+
+        it('should trigger the "create" event once after a bulkCreate', async () => {
+            const db = getMockDB()
+            const repo = getRepository(db)
+
+            const memberListener = {
+                callback: async () => {}
+            }
+
+            const memberSpy = vi.spyOn(memberListener, 'callback')
+
+            repo.on('create', 'members', memberListener.callback)
+
+            await repo.bulkCreate('members', [
+                { name: 'John' },
+                { name: 'Jane' }
+            ])
+
+            expect(memberSpy).toHaveBeenCalledTimes(1)
+            expect(memberSpy).toHaveBeenCalledWith([
+                { id: '0', name: 'John' },
+                { id: '1', name: 'Jane' }
+            ])
+        })
+
+        it('should trigger the "update" event once after a bulkUpdate', async () => {
+            const db = getMockDB()
+            const repo = getRepository(db)
+
+            seedMockRepository('members', [
+                { name: 'John' },
+                { name: 'Jane' },
+                { name: 'Jack' }
+            ])
+
+            const memberListener = {
+                callback: async () => {}
+            }
+
+            const memberSpy = vi.spyOn(memberListener, 'callback')
+
+            repo.on('update', 'members', memberListener.callback)
+
+            await repo.bulkUpdate('members', [
+                { id: '0', name: 'Jill' },
+                { id: '1', name: 'Jill' }
+            ])
+
+            expect(memberSpy).toHaveBeenCalledTimes(1)
+            expect(memberSpy).toHaveBeenCalledWith([
+                { id: '0', name: 'Jill' },
+                { id: '1', name: 'Jill' }
+            ])
+        })
+
+        it('should trigger the "remove" event once after a bulkRemove', async () => {
+            const db = getMockDB()
+            const repo = getRepository(db)
+
+            seedMockRepository('members', [
+                { name: 'John' },
+                { name: 'Jane' },
+                { name: 'Jack' }
+            ])
+
+            const memberListener = {
+                callback: async () => {}
+            }
+
+            const memberSpy = vi.spyOn(memberListener, 'callback')
+
+            repo.on('remove', 'members', memberListener.callback)
+
+            await repo.bulkRemove('members', ['1', '2'])
+
+            expect(memberSpy).toHaveBeenCalledTimes(1)
+            expect(memberSpy).toHaveBeenCalledWith({ id: ['1', '2'] })
+        })
     })
 })

--- a/src/repositories/interface.ts
+++ b/src/repositories/interface.ts
@@ -14,6 +14,9 @@ export interface Constraints<Row extends Entity> {
     where?: [keyof Row, Operators, any][]
 }
 
+export type RepositoryEventListener<Row extends Entity> = (
+    data: Row | Row[]
+) => Promise<void>
 export interface Repository {
     bulkCreate: <Row extends Entity & Partial<DBMeta>>(
         table: Table,
@@ -34,6 +37,18 @@ export interface Repository {
         table: Table,
         id: ID
     ) => Promise<(DBMeta & Row) | undefined>
+
+    off: <Row extends Entity>(
+        event: string,
+        table: Table,
+        callback?: RepositoryEventListener<Row>
+    ) => void
+
+    on: <Row extends Entity>(
+        event: string,
+        table: Table,
+        callback: RepositoryEventListener<Row>
+    ) => void
 
     query: <Row extends Entity>(
         table: Table,


### PR DESCRIPTION
 - `repo` kann nach wie vor von `q-core` verwendet werden.
 - Listeners können mit `repo.on("update", "table", data => {})` hinzugefügt werden.
 - Listeners können mit `repo.off("update", "table", callback)` für die jeweilige Tabelle entfernt werden.
 - Alle listeners für die jeweilige Tabelle können mit `repo.off("update", "table")` entfernt werden.
 - Es gibt listeners für `create`, `update` und `remove`.

TBD:

- Unterscheiden zwischen `create` und `bulkCreate`?