### PR TITLE
refactor: update dependencies

### DIFF
--- a/src/components/layout/Stack/Stack.styled.tsx
+++ b/src/components/layout/Stack/Stack.styled.tsx
@@ -1,28 +1,23 @@
 import { css } from '@emotion/react'
 import styled from '@emotion/styled'
-import React, { forwardRef } from 'react'
+import React from 'react'
 
 import { from } from '../../../utils/breakpoints'
 import { getDirectionSpacing, getFlexDirection } from '../../../utils/styles'
 
-import type { ForwardRefRenderFunction } from 'react'
-
 import type { StackProps } from './Stack'
 
-const StyledStack: ForwardRefRenderFunction<HTMLDivElement, StackProps> = (
-    {
-        alignItems: _alignItems,
-        as: Component = 'div',
-        children,
-        direction: _direction,
-        justifyContent: _justifyContent,
-        spacing: _spacing,
-        ...rest
-    },
-    ref
-) => React.createElement(Component, { ...rest, ref } as any, children)
+const StyledStack = ({
+    alignItems: _alignItems,
+    as: Component = 'div',
+    children,
+    direction: _direction,
+    justifyContent: _justifyContent,
+    spacing: _spacing,
+    ...rest
+}: StackProps) => React.createElement(Component, rest as any, children)
 
-export const Element = styled(forwardRef<HTMLDivElement, StackProps>(StyledStack))`
+export const Element = styled(StyledStack)`
     width: 100%;
 
     ${({ alignItems, direction, justifyContent }) =>

--- a/src/components/layout/Stack/Stack.tsx
+++ b/src/components/layout/Stack/Stack.tsx
@@ -1,10 +1,8 @@
 'use client'
 
-import { forwardRef } from 'react'
-
 import * as Styled from './Stack.styled'
 
-import type { ComponentType, ForwardRefRenderFunction, HTMLAttributes } from 'react'
+import type { ComponentType, HTMLAttributes, Ref } from 'react'
 
 import type { AlignItems, Breakpoints, JustifyContent, Spacing } from '../../../types'
 
@@ -16,12 +14,12 @@ export interface StackProps extends HTMLAttributes<HTMLDivElement> {
     breakpoints?: Breakpoints
     direction?: Direction
     justifyContent?: JustifyContent
+    ref?: Ref<HTMLDivElement>
     spacing?: Spacing
 }
 
-const Stack: ForwardRefRenderFunction<HTMLDivElement, StackProps> = (
-    { direction = 'vertical', spacing = 'default', ...props },
-    ref
-) => <Styled.Element direction={direction} ref={ref} spacing={spacing} {...props} />
+const Stack = ({ direction = 'vertical', spacing = 'default', ...props }: StackProps) => (
+    <Styled.Element direction={direction} spacing={spacing} {...props} />
+)
 
-export default forwardRef<HTMLDivElement, StackProps>(Stack)
+export default Stack

--- a/src/components/mui/Paper/Paper.styled.tsx
+++ b/src/components/mui/Paper/Paper.styled.tsx
@@ -1,23 +1,17 @@
 import styled from '@emotion/styled'
-import { forwardRef } from 'react'
-
-import type { ForwardedRef } from 'react'
 
 import type { PaperProps } from '.'
 
-const StyledPaper = (
-    {
-        borderRadius: _borderRadius,
-        height: _height,
-        overflow: _overflow,
-        scroll: _scroll,
-        width: _width,
-        ...rest
-    }: PaperProps,
-    ref: ForwardedRef<HTMLDivElement>
-) => <div {...rest} ref={ref} />
+const StyledPaper = ({
+    borderRadius: _borderRadius,
+    height: _height,
+    overflow: _overflow,
+    scroll: _scroll,
+    width: _width,
+    ...rest
+}: PaperProps) => <div {...rest} />
 
-export const Element = styled(forwardRef(StyledPaper))`
+export const Element = styled(StyledPaper)`
     position: relative;
     overflow: ${({ overflow }) => (overflow ? overflow : 'hidden')};
     width: ${({ width }) => (width ? width : 'auto')};

--- a/src/components/mui/Paper/Paper.tsx
+++ b/src/components/mui/Paper/Paper.tsx
@@ -1,12 +1,11 @@
 'use client'
 
-import { forwardRef } from 'react'
-
 import * as Styled from './Paper.styled'
 
-import type { ForwardedRef, HTMLAttributes } from 'react'
+import type { HTMLAttributes, Ref } from 'react'
 
 export interface PaperProps extends HTMLAttributes<HTMLDivElement> {
+    ref: Ref<HTMLDivElement>
     borderRadius?: string
     height?: string
     overflow?: string
@@ -14,8 +13,6 @@ export interface PaperProps extends HTMLAttributes<HTMLDivElement> {
     width?: string
 }
 
-const Paper = (props: PaperProps, ref: ForwardedRef<HTMLDivElement>) => (
-    <Styled.Element {...props} ref={ref} />
-)
+const Paper = (props: PaperProps) => <Styled.Element {...props} />
 
-export default forwardRef<HTMLDivElement, PaperProps>(Paper)
+export default Paper

--- a/src/components/mui/Paper/Paper.tsx
+++ b/src/components/mui/Paper/Paper.tsx
@@ -9,10 +9,11 @@ export interface PaperProps extends HTMLAttributes<HTMLDivElement> {
     borderRadius?: string
     height?: string
     overflow?: string
+    ownerState?: unknown
     scroll?: 'all' | 'x' | 'y'
     width?: string
 }
 
-const Paper = (props: PaperProps) => <Styled.Element {...props} />
+const Paper = ({ ownerState: _, ...props }: PaperProps) => <Styled.Element {...props} />
 
 export default Paper

--- a/src/components/mui/forms/DateRangePicker/DateRangePicker.tsx
+++ b/src/components/mui/forms/DateRangePicker/DateRangePicker.tsx
@@ -1,5 +1,4 @@
 import { DateRangePicker as DateRangePickerMui } from '@mui/x-date-pickers-pro'
-import { forwardRef } from 'react'
 import { Controller } from 'react-hook-form'
 
 import Paper from '../../Paper'
@@ -67,14 +66,14 @@ const DateRangePicker: FC<DateRangePickerProps> = ({
             slots={{
                 desktopPaper: Paper,
                 /*
-                field: forwardRef(function SingleInputDateRange(props, ref) {
-                    return <SingleInputDateRangeField {...props} ref={ref} />
-                }),
+                field: function SingleInputDateRange(props) {
+                    return <SingleInputDateRangeField {...props} />
+                },
                 */
                 fieldSeparator: () => null,
-                textField: forwardRef(function TextField(props: TextFieldProps, ref: any) {
-                    return <TextInput {...props} error={error} helperText={helperText} ref={ref} />
-                }),
+                textField: function TextField(props: TextFieldProps) {
+                    return <TextInput {...props} error={error} helperText={helperText} />
+                },
                 ...(slots ?? {}),
             }}
             {...props}

--- a/src/components/mui/forms/Select/Select.tsx
+++ b/src/components/mui/forms/Select/Select.tsx
@@ -3,7 +3,6 @@
 import { createFilterOptions } from '@mui/material/Autocomplete'
 import match from 'autosuggest-highlight/match'
 import parse from 'autosuggest-highlight/parse'
-import { forwardRef } from 'react'
 import { Controller } from 'react-hook-form'
 
 import { vars } from '../../../../utils/string'
@@ -22,6 +21,7 @@ type SelectProps = AutocompleteProps<any, any, any, any> & {
     onCreate: (value: any) => void
     onInputChange: (value: any) => void
     options: Array<{ key: string; value: string }>
+    ref: Ref<HTMLInputElement>
     control?: Control<FieldValues>
     createLabel?: string
     error?: boolean
@@ -31,25 +31,23 @@ type SelectProps = AutocompleteProps<any, any, any, any> & {
     multiple?: boolean
 }
 
-const Select = (
-    {
-        control,
-        createLabel,
-        defaultValue,
-        error,
-        fieldName,
-        helperText,
-        label,
-        limitTags = 2,
-        multiple,
-        onChange,
-        onCreate,
-        onInputChange,
-        options,
-        ...props
-    }: SelectProps,
-    ref: Ref<HTMLInputElement>
-) => {
+const Select = ({
+    control,
+    createLabel,
+    defaultValue,
+    error,
+    fieldName,
+    helperText,
+    label,
+    limitTags = 2,
+    multiple,
+    onChange,
+    onCreate,
+    onInputChange,
+    options,
+    ref,
+    ...props
+}: SelectProps) => {
     const handleChange = (values: any[] | any, field: ControllerRenderProps<FieldValues, any>) => {
         field.onChange(values)
 
@@ -216,4 +214,4 @@ export const objectsToOptions = (
     return objects
 }
 
-export default forwardRef<HTMLInputElement, SelectProps>(Select)
+export default Select

--- a/src/components/mui/forms/TextInput/TextInput.tsx
+++ b/src/components/mui/forms/TextInput/TextInput.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { forwardRef } from 'react'
 import { Controller } from 'react-hook-form'
 
 import * as Styled from './TextInput.styled'
@@ -13,23 +12,22 @@ export type TextInputProps = TextFieldProps & {
     control?: Control<FieldValues>
     fieldName?: string
     grow?: 'auto'
+    ref?: Ref<HTMLDivElement | null | undefined>
     round?: boolean
 }
 
-const TextInput = (
-    {
-        control,
-        defaultValue,
-        fieldName,
-        inputRef,
-        onChange,
-        round,
-        type,
-        value,
-        ...props
-    }: TextInputProps,
-    ref: Ref<HTMLDivElement | null | undefined>
-) => {
+const TextInput = ({
+    control,
+    defaultValue,
+    fieldName,
+    inputRef,
+    onChange,
+    ref,
+    round,
+    type,
+    value,
+    ...props
+}: TextInputProps) => {
     const setRef = (r: HTMLInputElement) =>
         [ref, inputRef].forEach((ref) => {
             if (ref) {
@@ -105,4 +103,4 @@ const TextInput = (
     )
 }
 
-export default forwardRef<HTMLDivElement | null | undefined, TextInputProps>(TextInput)
+export default TextInput


### PR DESCRIPTION
Migration zu React 19.

refs werden nun direkt als props weitergegeben.